### PR TITLE
Update materialy z GitHub.md

### DIFF
--- a/tutoriale/materialy z GitHub.md
+++ b/tutoriale/materialy z GitHub.md
@@ -1,10 +1,8 @@
 ## Przydatne materiały na Github
 
-W katalogu **colabs** można znaleźć notatniki z kodem: dotyczący wczytywania danych w formacie parquet oraz preprocessingu danych (z zeszłorocznego projektu) 
+W katalogu **code examples/colabs** można znaleźć notatniki z kodem: dotyczący wczytywania danych w formacie parquet oraz preprocessingu danych (z zeszłorocznego projektu) 
 
-W katalogu **notebooks** znajduje się przykładowy notatnik, template, który powstał jako wzór pisania notatników w tym folderze, a także notatnik z przykładowym kodem do wczytywania danych w kontekście Sparka
-
-W katalogu **stripped** jest plik z przykładowym kodem do wczytywania danych stripped.
+W katalogu **code examples/notebooks** znajduje się przykładowy notatnik, template, który powstał jako wzór pisania notatników w tym folderze, a także notatnik z przykładowym kodem do wczytywania danych w kontekście Sparka
 
 W katalogu **tutoriale** można znaleźć nastepujące tutoriale:
 * jak korzystać z GitHub-a (*Jak korzystac z GitHub.md*) oraz czym są git-hooki (*git-hooks.md*)
@@ -12,5 +10,5 @@ W katalogu **tutoriale** można znaleźć nastepujące tutoriale:
 * wstęp do pakietu MLlib (*MLlib.md*)
 * o preprocessingu danych w Apache Spark (*Preprocessing in Spark.md*)
 
-a także plik .sh z kodem do setupu Sparka (*setup_sparka.sh*)
+W katalogu **code examples/bash scripts** jest plik .sh z kodem do setupu Sparka (*setup_sparka.sh*)
 


### PR DESCRIPTION
Zorientowałam się, że po zmianach, ktore zrealizowałam w zadanie1iza (przeniesienie niektorych plików do innych katalogow czy usuniecie 1 pliku) markdown opisujacy materialy z Githuba i ich lokalizacje stal sie czesciowo nieaktualny - poprawilam  tekst, by opisywal rzeczywista aktualna lokalizacje plikow